### PR TITLE
Refactor the code to be able to reuse validation

### DIFF
--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<extension id="google_recaptcha" status="released" xmlns="http://symphony-cms.com/schemas/extension/1.0">
+<extension id="google_recaptcha" status="released" xmlns="http://getsymphony.com/schemas/extension/1.0">
 	<name>Google reCaptcha</name>
 	<description>Insert and process reCaptcha field for form submission</description>
 	<repo type="github">https://github.com/SagaraZD/google_recaptcha</repo>
 	<types>
 		<type>Third Party Integration</type>
+		<type>Captcha</type>
+		<type>reCaptcha</type>
 	</types>
 	<authors>
 		<author>
@@ -12,6 +14,12 @@
 		</author>
 	</authors>
 	<releases>
+		<release version="1.1.0" date="2017-09-28" min="2.6.x" max="2.x.x">
+			- Add validateChallenge() public method
+		</release>
+		<release version="1.0.1" date="2017-09-26" min="2.6.x" max="2.x.x">
+			- Refactor the http request to use the Gateway class
+		</release>
 		<release version="1.0" date="2017-08-24"  min="2.6.x" max="2.6.x" />
 	</releases>
 </extension>


### PR DESCRIPTION
This commits adds the public function validateChallenge() to be able to
validate captcha usign this code from outside of the event filter.

It also replaces the the curl code with Symphony's Gateway class, which
emulates curl when it is not available on the system.

Creates version 1.1.0

---

Sorry I should have create to separate commits for each version, but I forgot. And since the old code was gone, it was too much work. Any how, thanks for this extension!